### PR TITLE
Fix installation instructions for `go install` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ BrewKit focuses on repeatable builds, host agnostic and build process containeri
 ## Start with BrewKit
 
 Install BrewKit via go >= 1.20 
+
 ```shell
-go install github.com/ispringtech/brewkit
+go install github.com/ispringtech/brewkit/cmd/brewkit@latest
 ```
 
 Create `brewkit.jsonnet`


### PR DESCRIPTION
Hi, I noticed that the provided command for installation was failing with an error:

```shell
$ go install github.com/ispringtech/brewkit
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/ispringtech/brewkit@latest' to install the latest version
```

When specifying the version, I was getting this:

```shell
$ go install github.com/ispringtech/brewkit@latest
go: github.com/ispringtech/brewkit@latest: module github.com/ispringtech/brewkit@latest found (v1.0.0), but does not contain package github.com/ispringtech/brewkit
```

(I am using Go 1.24.2)

The problem is that the `main` package is not in the repository root, but in `cmd/brewkit`. I updated the command and now it works as intended, placing the binary in `~/go/bin/brewkit`.