### PR TITLE
Migrate from github.com/pkg/errors to std errors

### DIFF
--- a/cmd/brewkit/common.go
+++ b/cmd/brewkit/common.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"errors"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
 	"github.com/ispringtech/brewkit/internal/common/infrastructure/logger"

--- a/cmd/brewkit/config.go
+++ b/cmd/brewkit/config.go
@@ -3,10 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 
-	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
 	appconfig "github.com/ispringtech/brewkit/internal/frontend/app/config"
@@ -49,12 +49,12 @@ func configInit() *cli.Command {
 
 			err = os.MkdirAll(configDir, 0o755)
 			if err != nil {
-				return errors.Wrapf(err, "failed to create folder for config %s", configDir)
+				return fmt.Errorf("failed to create folder for config %s: %w", configDir, err)
 			}
 
 			err = os.WriteFile(configPath, defaultConfigBuffer.Bytes(), 0o600)
 			if err != nil {
-				return errors.Wrapf(err, "failed to write file for config %s", configDir)
+				return fmt.Errorf("failed to write file for config %s: %w", configDir, err)
 			}
 
 			logger.Outputf("Default config created in %s\n", configPath)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/google/go-jsonnet v0.20.0
-	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.25.1
 	golang.org/x/exp v0.0.0-20230420155640-133eef4313cb
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHH
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-jsonnet v0.20.0 h1:WG4TTSARuV7bSm4PMB4ohjxe33IHT5WVTrJSU33uT4g=
 github.com/google/go-jsonnet v0.20.0/go.mod h1:VbgWF9JX7ztlv770x/TolZNGGFfiHEVx9G6ca2eUmeA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=

--- a/internal/backend/app/build/service.go
+++ b/internal/backend/app/build/service.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/ispringtech/brewkit/internal/backend/api"
 	"github.com/ispringtech/brewkit/internal/backend/app/docker"
 	"github.com/ispringtech/brewkit/internal/backend/app/dockerfile"
@@ -70,7 +68,7 @@ func (service *buildService) calculateVars(ctx context.Context, vars []api.Var) 
 
 	d, err := dockerfile.NewVarGenerator(service.dockerfileImage).GenerateDockerfile(vars)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate dockerfile for variables")
+		return nil, fmt.Errorf("failed to generate dockerfile for variables: %w", err)
 	}
 
 	res := map[string]string{}
@@ -89,7 +87,7 @@ func (service *buildService) calculateVars(ctx context.Context, vars []api.Var) 
 			UseCache: false, // Disable cache for retrieving variable value
 		})
 		if err2 != nil {
-			return nil, errors.Wrapf(err2, "failed to calculate %s var", v.Name)
+			return nil, fmt.Errorf("failed to calculate %s var: %w", v.Name, err2)
 		}
 
 		res[v.Name] = string(data)
@@ -205,7 +203,7 @@ func (service *buildService) prePullImages(
 	})
 	existingImages, err := service.dockerClient.ListImages(ctx, imagesSlice)
 	if err != nil {
-		return errors.Wrap(err, "failed to filter existing images")
+		return fmt.Errorf("failed to filter existing images: %w", err)
 	}
 
 	imagesToPull := slices.Diff(imagesSlice, slices.Map(existingImages, func(img docker.Image) string {

--- a/internal/backend/app/dockerfile/targetgenerator.go
+++ b/internal/backend/app/dockerfile/targetgenerator.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
-
 	"github.com/ispringtech/brewkit/internal/backend/api"
 	"github.com/ispringtech/brewkit/internal/common/maps"
 	"github.com/ispringtech/brewkit/internal/common/maybe"
@@ -66,7 +64,7 @@ func (generator targetGenerator) stagesForTarget(v api.Vertex) ([]dockerfile.Sta
 
 		s, err = generator.stages(v.Name, stage)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to generate instructions for target %s", v.Name)
+			return nil, fmt.Errorf("failed to generate instructions for target %s: %w", v.Name, err)
 		}
 		stages = append(stages, s...)
 	}
@@ -117,7 +115,7 @@ func (generator targetGenerator) stages(name string, stage api.Stage) ([]dockerf
 
 	instructions, err := generator.instructionsForStage(stage)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate instructions for stage")
+		return nil, fmt.Errorf("failed to generate instructions for stage: %w", err)
 	}
 
 	stages := []dockerfile.Stage{

--- a/internal/backend/infrastructure/docker/client.go
+++ b/internal/backend/infrastructure/docker/client.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/pkg/errors"
-
 	"github.com/ispringtech/brewkit/internal/backend/app/docker"
 	"github.com/ispringtech/brewkit/internal/common/infrastructure/executor"
 	"github.com/ispringtech/brewkit/internal/common/infrastructure/logger"
@@ -148,7 +146,7 @@ func (c *client) ListImages(ctx context.Context, images []string) ([]docker.Imag
 	output := &bytes.Buffer{}
 	err := c.dockerExecutor.Run(ctx, args, executor.RunParams{Stdout: maybe.NewJust[io.Writer](output)})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list docker images")
+		return nil, fmt.Errorf("failed to list docker images: %w", err)
 	}
 
 	var res []docker.Image

--- a/internal/backend/infrastructure/docker/outputparser.go
+++ b/internal/backend/infrastructure/docker/outputparser.go
@@ -2,12 +2,12 @@ package docker
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
 	"io"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -52,7 +52,7 @@ func (p outputParser) parseBuildOutputForRunTarget(output io.Reader) ([]byte, er
 
 		commandOutput, err := scanCommandOutput(scanner)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to scan command output")
+			return nil, fmt.Errorf("failed to scan command output: %w", err)
 		}
 
 		return []byte(commandOutput), nil
@@ -68,7 +68,7 @@ func scanCommandOutput(scanner *bufio.Scanner) (string, error) {
 
 		submatch := outputLine.FindStringSubmatch(line)
 		if len(submatch) != len(outputLine.SubexpNames()) {
-			return "", errors.Errorf("invalid output line format: %s", line)
+			return "", fmt.Errorf("invalid output line format: %s", line)
 		}
 
 		mark := submatch[1]
@@ -82,24 +82,24 @@ func scanCommandOutput(scanner *bufio.Scanner) (string, error) {
 	}
 
 	output := strings.Join(res, "\n")
-	return "", errors.Errorf("output line is not terminated by %s: current line: %s", doneSymbol, output)
+	return "", fmt.Errorf("output line is not terminated by %s: current line: %s", doneSymbol, output)
 }
 
 func completed(progress string) (bool, error) {
 	const progressSeparator = "/"
 	parts := strings.Split(progress, progressSeparator)
 	if len(parts) != 2 {
-		return false, errors.Errorf("incorrect progress format %s", progress)
+		return false, fmt.Errorf("incorrect progress format %s", progress)
 	}
 
 	readyPart, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return false, errors.Errorf("incorrect progress format %s", progress)
+		return false, fmt.Errorf("incorrect progress format %s", progress)
 	}
 
 	allPart, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return false, errors.Errorf("incorrect progress format %s", progress)
+		return false, fmt.Errorf("incorrect progress format %s", progress)
 	}
 
 	return readyPart == allPart, nil

--- a/internal/backend/infrastructure/ssh/agentprovider.go
+++ b/internal/backend/infrastructure/ssh/agentprovider.go
@@ -1,9 +1,8 @@
 package ssh
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 
 	"github.com/ispringtech/brewkit/internal/backend/app/ssh"
 )
@@ -15,7 +14,7 @@ const (
 func NewAgentProvider() (ssh.AgentProvider, error) {
 	socket, found := os.LookupEnv(sshAuthSock)
 	if !found {
-		return nil, errors.Errorf("ssh auth socket via env %s not found", sshAuthSock)
+		return nil, fmt.Errorf("ssh auth socket via env %s not found", sshAuthSock)
 	}
 
 	return &agentProvider{defaultAgent: socket}, nil

--- a/internal/frontend/app/builddefinition/builder.go
+++ b/internal/frontend/app/builddefinition/builder.go
@@ -1,7 +1,7 @@
 package builddefinition
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/ispringtech/brewkit/internal/backend/api"
 	"github.com/ispringtech/brewkit/internal/common/maybe"
@@ -23,7 +23,7 @@ type builder struct{}
 
 func (builder builder) Build(c buildconfig.Config, secrets []config.Secret) (Definition, error) {
 	if c.APIVersion != version.APIVersionV1 {
-		return Definition{}, errors.Wrapf(ErrUnsupportedAPIVersion, "version: %s", c.APIVersion)
+		return Definition{}, fmt.Errorf("version: %s: %w", c.APIVersion, ErrUnsupportedAPIVersion)
 	}
 
 	vertexes, err := newVertexGraphBuilder(secrets, c.Targets).graphVertexes()
@@ -46,7 +46,7 @@ func (builder builder) variables(vars []buildconfig.VarData, secrets []config.Se
 	return slices.MapErr(vars, func(v buildconfig.VarData) (api.Var, error) {
 		mappedSecrets, err := mapSecrets(v.Secrets, secrets)
 		if err != nil {
-			return api.Var{}, errors.Wrapf(err, "failed to map secrets in %s variable", v.Name)
+			return api.Var{}, fmt.Errorf("failed to map secrets in %s variable: %w", v.Name, err)
 		}
 
 		return api.Var{

--- a/internal/frontend/app/builddefinition/errors.go
+++ b/internal/frontend/app/builddefinition/errors.go
@@ -1,7 +1,7 @@
 package builddefinition
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 var (

--- a/internal/frontend/app/config/defaults.go
+++ b/internal/frontend/app/config/defaults.go
@@ -3,8 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -18,7 +16,7 @@ var (
 func DefaultConfigPath() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to receive user home dir")
+		return "", fmt.Errorf("failed to receive user home dir: %w", err)
 	}
 
 	return fmt.Sprintf(defaultConfigPath, homeDir), nil

--- a/internal/frontend/app/service/build.go
+++ b/internal/frontend/app/service/build.go
@@ -3,8 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/ispringtech/brewkit/internal/backend/api"
 	"github.com/ispringtech/brewkit/internal/common/maybe"
@@ -100,7 +99,7 @@ func (service *buildService) DumpBuildDefinition(_ context.Context, configPath s
 
 	d, err := json.Marshal(definition)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", err
 	}
 
 	return string(d), nil
@@ -113,7 +112,7 @@ func (service *buildService) DumpCompiledBuildDefinition(_ context.Context, conf
 func (service *buildService) buildVertex(targets []string, definition builddefinition.Definition) (api.Vertex, error) {
 	if len(targets) == 0 {
 		v, err := service.findTarget(allTargetKeyword, definition)
-		return v, errors.Wrap(err, "failed to find default target")
+		return v, fmt.Errorf("failed to find default target: %w", err)
 	}
 
 	if len(targets) == 1 {
@@ -136,7 +135,7 @@ func (service *buildService) buildVertex(targets []string, definition builddefin
 func (service *buildService) findTarget(target string, definition builddefinition.Definition) (api.Vertex, error) {
 	vertex := definition.Vertex(target)
 	if !maybe.Valid(vertex) {
-		return api.Vertex{}, errors.Errorf("target %s not found", target)
+		return api.Vertex{}, fmt.Errorf("target %s not found", target)
 	}
 	return maybe.Just(vertex), nil
 }

--- a/internal/frontend/app/service/build.go
+++ b/internal/frontend/app/service/build.go
@@ -112,7 +112,11 @@ func (service *buildService) DumpCompiledBuildDefinition(_ context.Context, conf
 func (service *buildService) buildVertex(targets []string, definition builddefinition.Definition) (api.Vertex, error) {
 	if len(targets) == 0 {
 		v, err := service.findTarget(allTargetKeyword, definition)
-		return v, fmt.Errorf("failed to find default target: %w", err)
+		if err != nil {
+			return api.Vertex{}, fmt.Errorf("failed to find default target: %w", err)
+		}
+
+		return v, nil
 	}
 
 	if len(targets) == 1 {

--- a/internal/frontend/infrastructure/builddefinition/nativefunc.go
+++ b/internal/frontend/infrastructure/builddefinition/nativefunc.go
@@ -1,9 +1,10 @@
 package builddefinition
 
 import (
+	"fmt"
+
 	"github.com/google/go-jsonnet"
 	"github.com/google/go-jsonnet/ast"
-	"github.com/pkg/errors"
 )
 
 type nativeFunc interface {
@@ -25,7 +26,7 @@ func (f nativeFunc2[V1, V2]) nativeFunc() *jsonnet.NativeFunction {
 			func(i []interface{}) (interface{}, error) {
 				const argsCount = 2
 				if len(i) != argsCount {
-					return nil, errors.Errorf("not enough arguments to call, expected %d", argsCount)
+					return nil, fmt.Errorf("not enough arguments to call, expected %d", argsCount)
 				}
 
 				v1, err := checkArg[V1](f.v1, i[0])
@@ -64,7 +65,7 @@ func (f nativeFunc3[V1, V2, V3]) nativeFunc() *jsonnet.NativeFunction {
 			func(i []interface{}) (interface{}, error) {
 				const argsCount = 3
 				if len(i) != argsCount {
-					return nil, errors.Errorf("not enough arguments to call, expected %d", argsCount)
+					return nil, fmt.Errorf("not enough arguments to call, expected %d", argsCount)
 				}
 
 				v1, err := checkArg[V1](f.v1, i[0])
@@ -97,7 +98,7 @@ func errWrapper(name string, next func(i []interface{}) (interface{}, error)) fu
 	return func(i []interface{}) (interface{}, error) {
 		json, err := next(i)
 		if err != nil {
-			err = errors.Wrapf(err, "call '%s' failed", name)
+			err = fmt.Errorf("call '%s' failed: %w", name, err)
 		}
 		return json, err
 	}
@@ -112,7 +113,7 @@ func checkArg[V any](arg argDesc, argV interface{}) (v V, err error) {
 	var ok bool
 	v, ok = argV.(V)
 	if !ok {
-		return v, errors.Errorf("expected '%T' got '%T' as %s arg", v, argV, arg.name)
+		return v, fmt.Errorf("expected '%T' got '%T' as %s arg", v, argV, arg.name)
 	}
 	return v, nil
 }

--- a/internal/frontend/infrastructure/builddefinition/parser.go
+++ b/internal/frontend/infrastructure/builddefinition/parser.go
@@ -2,11 +2,11 @@ package builddefinition
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 
 	"github.com/google/go-jsonnet"
-	"github.com/pkg/errors"
 
 	"github.com/ispringtech/brewkit/internal/common/either"
 	"github.com/ispringtech/brewkit/internal/common/maybe"
@@ -26,7 +26,7 @@ func (parser Parser) Parse(configPath string) (buildconfig.Config, error) {
 
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
-		return buildconfig.Config{}, errors.Wrap(err, "failed to parse json config")
+		return buildconfig.Config{}, fmt.Errorf("failed to parse json config: %w", err)
 	}
 
 	return mapConfig(c), nil
@@ -39,7 +39,7 @@ func (parser Parser) CompileConfig(configPath string) (string, error) {
 func (parser Parser) compileConfig(configPath string) (string, error) {
 	fileBytes, err := os.ReadFile(configPath)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to read build config file")
+		return "", fmt.Errorf("failed to read build config file: %w", err)
 	}
 
 	vm := jsonnet.MakeVM()
@@ -49,7 +49,7 @@ func (parser Parser) compileConfig(configPath string) (string, error) {
 	}
 
 	data, err := vm.EvaluateAnonymousSnippet(path.Base(configPath), string(fileBytes))
-	return data, errors.Wrap(err, "failed to compile jsonnet for build definition")
+	return data, fmt.Errorf("failed to compile jsonnet for build definition: %w", err)
 }
 
 func mapConfig(c Config) buildconfig.Config {

--- a/internal/frontend/infrastructure/builddefinition/parser.go
+++ b/internal/frontend/infrastructure/builddefinition/parser.go
@@ -49,7 +49,11 @@ func (parser Parser) compileConfig(configPath string) (string, error) {
 	}
 
 	data, err := vm.EvaluateAnonymousSnippet(path.Base(configPath), string(fileBytes))
-	return data, fmt.Errorf("failed to compile jsonnet for build definition: %w", err)
+	if err != nil {
+		return "", fmt.Errorf("failed to compile jsonnet for build definition: %w", err)
+	}
+
+	return data, nil
 }
 
 func mapConfig(c Config) buildconfig.Config {

--- a/internal/frontend/infrastructure/config/parser.go
+++ b/internal/frontend/infrastructure/config/parser.go
@@ -62,5 +62,9 @@ func (p Parser) Dump(srcConfig config.Config) ([]byte, error) {
 	}
 
 	data, err := json.Marshal(c)
-	return data, fmt.Errorf("failed to marshal config to json: %w", err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config to json: %w", err)
+	}
+
+	return data, nil
 }

--- a/internal/frontend/infrastructure/jsonnet/formatter.go
+++ b/internal/frontend/infrastructure/jsonnet/formatter.go
@@ -22,5 +22,9 @@ func (formatter Formatter) Format(configPath string) (string, error) {
 	options.StringStyle = jsonnetformatter.StringStyleLeave
 
 	data, err := jsonnetformatter.Format(filename, string(configData), options)
-	return data, fmt.Errorf("failed to format config file: %w", err)
+	if err != nil {
+		return "", fmt.Errorf("failed to format config file: %w", err)
+	}
+
+	return data, nil
 }

--- a/internal/frontend/infrastructure/jsonnet/formatter.go
+++ b/internal/frontend/infrastructure/jsonnet/formatter.go
@@ -1,11 +1,11 @@
 package jsonnet
 
 import (
+	"fmt"
 	"os"
 	"path"
 
 	jsonnetformatter "github.com/google/go-jsonnet/formatter"
-	"github.com/pkg/errors"
 )
 
 type Formatter struct{}
@@ -22,5 +22,5 @@ func (formatter Formatter) Format(configPath string) (string, error) {
 	options.StringStyle = jsonnetformatter.StringStyleLeave
 
 	data, err := jsonnetformatter.Format(filename, string(configData), options)
-	return data, errors.Wrap(err, "failed to format config file")
+	return data, fmt.Errorf("failed to format config file: %w", err)
 }


### PR DESCRIPTION
The `github.com/pkg/errors` package is unmaintained and archived due to native error wrapping support in the `errors` package.

## Conversion rules

* `errors.Errorf` -> `fmt.Errorf`
* `errors.Wrap(err, "…")` -> `fmt.Errorf("…: %w", err)` with `if err != nil` checks where necessary
* `errors.Wrapf(err, "… %s: %s", foo, bar)` -> `fmt.Errorf("… %s: %s: %w", foo, bar err)` with `if err != nil` checks where necessary

## Quality control

I ran a couple of builds with malformed config and made sure, that the errors are formatted correctly. Other than that, there is no changes in the overall behavior.

Resolves #2